### PR TITLE
change api.mustache template to add url parser and update client

### DIFF
--- a/pkg/tsuru/api_app.go
+++ b/pkg/tsuru/api_app.go
@@ -45,7 +45,18 @@ func (a *AppApiService) AppCreate(ctx context.Context, app App) (AppCreateRespon
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/apps"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -187,8 +198,19 @@ func (a *AppApiService) AppDelete(ctx context.Context, app string) (*http.Respon
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -303,8 +325,19 @@ func (a *AppApiService) AppGet(ctx context.Context, app string) (App, *http.Resp
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -451,7 +484,18 @@ func (a *AppApiService) AppList(ctx context.Context, localVarOptionals *AppListO
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/apps"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -589,8 +633,19 @@ func (a *AppApiService) AppQuotaChange(ctx context.Context, app string, limit fl
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}/quota"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}/quota"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -723,8 +778,19 @@ func (a *AppApiService) AppQuotaGet(ctx context.Context, app string) (Quota, *ht
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}/quota"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}/quota"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -854,8 +920,19 @@ func (a *AppApiService) AppRestart(ctx context.Context, app string, localVarOpti
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}/restart"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}/restart"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -971,8 +1048,19 @@ func (a *AppApiService) AppUpdate(ctx context.Context, app string) (*http.Respon
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1111,8 +1199,19 @@ func (a *AppApiService) EnvGet(ctx context.Context, app string, localVarOptional
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}/env"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}/env"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1241,8 +1340,19 @@ func (a *AppApiService) EnvSet(ctx context.Context, app string, envSetData EnvSe
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}/env"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}/env"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1379,8 +1489,19 @@ func (a *AppApiService) EnvUnset(ctx context.Context, app string, env []string, 
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/apps/{app}/env"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/apps/{app}/env"
 	localVarPath = strings.Replace(localVarPath, "{"+"app"+"}", fmt.Sprintf("%v", app), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_auth.go
+++ b/pkg/tsuru/api_auth.go
@@ -42,8 +42,19 @@ func (a *AuthApiService) AssignRoleToToken(ctx context.Context, roleName string,
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/roles/{role_name}/token"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/roles/{role_name}/token"
 	localVarPath = strings.Replace(localVarPath, "{"+"role_name"+"}", fmt.Sprintf("%v", roleName), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -157,9 +168,20 @@ func (a *AuthApiService) DissociateRoleFromToken(ctx context.Context, roleName s
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/roles/{role_name}/token/{token_id}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/roles/{role_name}/token/{token_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"role_name"+"}", fmt.Sprintf("%v", roleName), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"token_id"+"}", fmt.Sprintf("%v", tokenId), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -272,7 +294,18 @@ func (a *AuthApiService) TeamTokenCreate(ctx context.Context, teamTokenCreateArg
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/tokens"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.6/tokens"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -394,8 +427,19 @@ func (a *AuthApiService) TeamTokenDelete(ctx context.Context, tokenId string) (*
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/tokens/{token_id}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/tokens/{token_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"token_id"+"}", fmt.Sprintf("%v", tokenId), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -510,8 +554,19 @@ func (a *AuthApiService) TeamTokenInfo(ctx context.Context, tokenId string) (Tea
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.7/tokens/{token_id}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.7/tokens/{token_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"token_id"+"}", fmt.Sprintf("%v", tokenId), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -637,8 +692,19 @@ func (a *AuthApiService) TeamTokenUpdate(ctx context.Context, tokenId string, te
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/tokens/{token_id}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.6/tokens/{token_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"token_id"+"}", fmt.Sprintf("%v", tokenId), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -764,7 +830,18 @@ func (a *AuthApiService) TeamTokensList(ctx context.Context) ([]TeamToken, *http
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/tokens"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.6/tokens"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_cluster.go
+++ b/pkg/tsuru/api_cluster.go
@@ -41,7 +41,18 @@ func (a *ClusterApiService) ClusterCreate(ctx context.Context, cluster Cluster) 
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.3/provisioner/clusters"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.3/provisioner/clusters"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -153,8 +164,19 @@ func (a *ClusterApiService) ClusterDelete(ctx context.Context, clusterName strin
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.3/provisioner/clusters/{cluster_name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.3/provisioner/clusters/{cluster_name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"cluster_name"+"}", fmt.Sprintf("%v", clusterName), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -269,8 +291,19 @@ func (a *ClusterApiService) ClusterInfo(ctx context.Context, clusterName string)
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.8/provisioner/clusters/{cluster_name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.8/provisioner/clusters/{cluster_name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"cluster_name"+"}", fmt.Sprintf("%v", clusterName), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -394,7 +427,18 @@ func (a *ClusterApiService) ClusterList(ctx context.Context) ([]Cluster, *http.R
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.3/provisioner/clusters"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.3/provisioner/clusters"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -515,8 +559,19 @@ func (a *ClusterApiService) ClusterUpdate(ctx context.Context, clusterName strin
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/provisioner/clusters/{cluster_name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.4/provisioner/clusters/{cluster_name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"cluster_name"+"}", fmt.Sprintf("%v", clusterName), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -649,7 +704,18 @@ func (a *ClusterApiService) ProvisionerList(ctx context.Context) ([]Provisioner,
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.7/provisioner"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.7/provisioner"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_event.go
+++ b/pkg/tsuru/api_event.go
@@ -41,8 +41,19 @@ func (a *EventApiService) EventCancel(ctx context.Context, eventid string, event
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.1/events/{eventid}/cancel"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.1/events/{eventid}/cancel"
 	localVarPath = strings.Replace(localVarPath, "{"+"eventid"+"}", fmt.Sprintf("%v", eventid), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -170,7 +181,18 @@ func (a *EventApiService) WebhookCreate(ctx context.Context, webhook Webhook) (*
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/events/webhooks"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/events/webhooks"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -298,8 +320,19 @@ func (a *EventApiService) WebhookDelete(ctx context.Context, name string) (*http
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/events/webhooks/{name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/events/webhooks/{name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", fmt.Sprintf("%v", name), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -430,8 +463,19 @@ func (a *EventApiService) WebhookGet(ctx context.Context, name string) (Webhook,
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/events/webhooks/{name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.6/events/webhooks/{name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", fmt.Sprintf("%v", name), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -554,7 +598,18 @@ func (a *EventApiService) WebhookList(ctx context.Context) ([]Webhook, *http.Res
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/events/webhooks"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.6/events/webhooks"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -654,8 +709,19 @@ func (a *EventApiService) WebhookUpdate(ctx context.Context, name string, webhoo
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/events/webhooks/{name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/events/webhooks/{name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", fmt.Sprintf("%v", name), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_node.go
+++ b/pkg/tsuru/api_node.go
@@ -41,7 +41,18 @@ func (a *NodeApiService) NodeAdd(ctx context.Context, nodeAddData NodeAddData) (
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.2/node"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.2/node"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -155,8 +166,19 @@ func (a *NodeApiService) NodeDelete(ctx context.Context, address string, noRebal
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.2/node/{address}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.2/node/{address}"
 	localVarPath = strings.Replace(localVarPath, "{"+"address"+"}", fmt.Sprintf("%v", address), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -273,8 +295,19 @@ func (a *NodeApiService) NodeGet(ctx context.Context, address string) (NodeGetRe
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.2/node/{address}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.2/node/{address}"
 	localVarPath = strings.Replace(localVarPath, "{"+"address"+"}", fmt.Sprintf("%v", address), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -398,7 +431,18 @@ func (a *NodeApiService) NodeList(ctx context.Context) (NodeListResponse, *http.
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.2/node"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.2/node"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -498,7 +542,18 @@ func (a *NodeApiService) NodeUpdate(ctx context.Context, nodeUpdateData NodeUpda
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.2/node"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.2/node"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_platform.go
+++ b/pkg/tsuru/api_platform.go
@@ -43,7 +43,18 @@ func (a *PlatformApiService) PlatformAdd(ctx context.Context, name string, docke
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/platforms"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/platforms"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -162,8 +173,19 @@ func (a *PlatformApiService) PlatformDelete(ctx context.Context, platform string
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/platforms/{platform}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/platforms/{platform}"
 	localVarPath = strings.Replace(localVarPath, "{"+"platform"+"}", fmt.Sprintf("%v", platform), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -278,8 +300,19 @@ func (a *PlatformApiService) PlatformInfo(ctx context.Context, platform string) 
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/platforms/{platform}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.6/platforms/{platform}"
 	localVarPath = strings.Replace(localVarPath, "{"+"platform"+"}", fmt.Sprintf("%v", platform), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -403,7 +436,18 @@ func (a *PlatformApiService) PlatformList(ctx context.Context) ([]Platform, *htt
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/platforms"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/platforms"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -514,8 +558,19 @@ func (a *PlatformApiService) PlatformRollback(ctx context.Context, platform stri
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/platforms/{platform}/rollback"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/platforms/{platform}/rollback"
 	localVarPath = strings.Replace(localVarPath, "{"+"platform"+"}", fmt.Sprintf("%v", platform), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -647,8 +702,19 @@ func (a *PlatformApiService) PlatformUpdate(ctx context.Context, platform string
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/platforms/{platform}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/platforms/{platform}"
 	localVarPath = strings.Replace(localVarPath, "{"+"platform"+"}", fmt.Sprintf("%v", platform), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_pool.go
+++ b/pkg/tsuru/api_pool.go
@@ -41,7 +41,18 @@ func (a *PoolApiService) PoolCreate(ctx context.Context, poolCreateData PoolCrea
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/pools"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/pools"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -170,8 +181,19 @@ func (a *PoolApiService) PoolDelete(ctx context.Context, pool string) (*http.Res
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pools/{pool}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/pools/{pool}"
 	localVarPath = strings.Replace(localVarPath, "{"+"pool"+"}", fmt.Sprintf("%v", pool), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -300,8 +322,19 @@ func (a *PoolApiService) PoolGet(ctx context.Context, pool string) (Pool, *http.
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pools/{pool}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/pools/{pool}"
 	localVarPath = strings.Replace(localVarPath, "{"+"pool"+"}", fmt.Sprintf("%v", pool), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -422,7 +455,18 @@ func (a *PoolApiService) PoolList(ctx context.Context) ([]Pool, *http.Response, 
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/pools"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/pools"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -533,8 +577,19 @@ func (a *PoolApiService) PoolUpdate(ctx context.Context, pool string, poolUpdate
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pools/{pool}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/pools/{pool}"
 	localVarPath = strings.Replace(localVarPath, "{"+"pool"+"}", fmt.Sprintf("%v", pool), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_service.go
+++ b/pkg/tsuru/api_service.go
@@ -45,9 +45,20 @@ func (a *ServiceApiService) InstanceDelete(ctx context.Context, service string, 
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/services/{service}/instances/{instance}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/services/{service}/instances/{instance}"
 	localVarPath = strings.Replace(localVarPath, "{"+"service"+"}", fmt.Sprintf("%v", service), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"instance"+"}", fmt.Sprintf("%v", instance), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -167,9 +178,20 @@ func (a *ServiceApiService) InstanceGet(ctx context.Context, service string, ins
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/services/{service}/instances/{instance}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/services/{service}/instances/{instance}"
 	localVarPath = strings.Replace(localVarPath, "{"+"service"+"}", fmt.Sprintf("%v", service), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"instance"+"}", fmt.Sprintf("%v", instance), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -303,9 +325,20 @@ func (a *ServiceApiService) InstanceUpdate(ctx context.Context, service string, 
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/services/{service}/instances/{instance}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/services/{service}/instances/{instance}"
 	localVarPath = strings.Replace(localVarPath, "{"+"service"+"}", fmt.Sprintf("%v", service), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"instance"+"}", fmt.Sprintf("%v", instance), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -455,7 +488,18 @@ func (a *ServiceApiService) InstancesList(ctx context.Context, localVarOptionals
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/services/instances"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/services/instances"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -568,7 +612,18 @@ func (a *ServiceApiService) ServiceBrokerCreate(ctx context.Context, serviceBrok
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.7/brokers"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.7/brokers"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -696,8 +751,19 @@ func (a *ServiceApiService) ServiceBrokerDelete(ctx context.Context, name string
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.7/brokers/{name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.7/brokers/{name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", fmt.Sprintf("%v", name), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -828,7 +894,18 @@ func (a *ServiceApiService) ServiceBrokerList(ctx context.Context) (ServiceBroke
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.7/brokers"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.7/brokers"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -939,8 +1016,19 @@ func (a *ServiceApiService) ServiceBrokerUpdate(ctx context.Context, name string
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.7/brokers/{name}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.7/brokers/{name}"
 	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", fmt.Sprintf("%v", name), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1073,7 +1161,18 @@ func (a *ServiceApiService) ServicesList(ctx context.Context) ([]Service, *http.
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/services"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/services"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_team.go
+++ b/pkg/tsuru/api_team.go
@@ -41,7 +41,18 @@ func (a *TeamApiService) TeamCreate(ctx context.Context, teamCreateArgs TeamCrea
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/teams"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/teams"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -170,8 +181,19 @@ func (a *TeamApiService) TeamDelete(ctx context.Context, team string) (*http.Res
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/teams/{team}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/teams/{team}"
 	localVarPath = strings.Replace(localVarPath, "{"+"team"+"}", fmt.Sprintf("%v", team), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -300,8 +322,19 @@ func (a *TeamApiService) TeamGet(ctx context.Context, team string) (TeamInfo, *h
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/teams/{team}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.4/teams/{team}"
 	localVarPath = strings.Replace(localVarPath, "{"+"team"+"}", fmt.Sprintf("%v", team), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -422,8 +455,19 @@ func (a *TeamApiService) TeamUpdate(ctx context.Context, team string, teamUpdate
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.6/teams/{team}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.6/teams/{team}"
 	localVarPath = strings.Replace(localVarPath, "{"+"team"+"}", fmt.Sprintf("%v", team), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -553,7 +597,18 @@ func (a *TeamApiService) TeamsList(ctx context.Context) ([]Team, *http.Response,
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/teams"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/teams"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_user.go
+++ b/pkg/tsuru/api_user.go
@@ -45,7 +45,18 @@ func (a *UserApiService) APITokenGet(ctx context.Context, email string) (string,
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/api-key"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/users/api-key"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -168,7 +179,18 @@ func (a *UserApiService) APITokenRegenerate(ctx context.Context, email string) (
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/api-key"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/users/api-key"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -299,7 +321,18 @@ func (a *UserApiService) ChangePassword(ctx context.Context, localVarOptionals *
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/password"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users/password"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -453,8 +486,19 @@ func (a *UserApiService) ResetPassword(ctx context.Context, email string, body s
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/{email}/password"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users/{email}/password"
 	localVarPath = strings.Replace(localVarPath, "{"+"email"+"}", fmt.Sprintf("%v", email), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -603,7 +647,18 @@ func (a *UserApiService) SSHKeyAdd(ctx context.Context, sshKeyAddData SshKeyAddD
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/keys"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users/keys"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -733,7 +788,18 @@ func (a *UserApiService) SSHKeyList(ctx context.Context) (SshKeyListResponse, *h
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/keys"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/users/keys"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -853,8 +919,19 @@ func (a *UserApiService) SSHKeyRemove(ctx context.Context, key string) (*http.Re
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/keys/{key}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users/keys/{key}"
 	localVarPath = strings.Replace(localVarPath, "{"+"key"+"}", fmt.Sprintf("%v", key), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -984,7 +1061,18 @@ func (a *UserApiService) UserCreate(ctx context.Context, userData UserData) (*ht
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1130,7 +1218,18 @@ func (a *UserApiService) UserDelete(ctx context.Context, email string) (*http.Re
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1245,7 +1344,18 @@ func (a *UserApiService) UserGet(ctx context.Context) (User, *http.Response, err
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/info"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/users/info"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1356,8 +1466,19 @@ func (a *UserApiService) UserQuotaChange(ctx context.Context, email string, limi
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/{email}/quota"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users/{email}/quota"
 	localVarPath = strings.Replace(localVarPath, "{"+"email"+"}", fmt.Sprintf("%v", email), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1490,8 +1611,19 @@ func (a *UserApiService) UserQuotaGet(ctx context.Context, email string) (UserQu
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/{email}/quota"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/users/{email}/quota"
 	localVarPath = strings.Replace(localVarPath, "{"+"email"+"}", fmt.Sprintf("%v", email), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1613,7 +1745,18 @@ func (a *UserApiService) UserTokenDelete(ctx context.Context) (*http.Response, e
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users/tokens"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.0/users/tokens"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1700,7 +1843,18 @@ func (a *UserApiService) UsersList(ctx context.Context, email string, localVarOp
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.0/users"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.0/users"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/pkg/tsuru/api_volume.go
+++ b/pkg/tsuru/api_volume.go
@@ -50,8 +50,19 @@ func (a *VolumeApiService) VolumeBind(ctx context.Context, volume string, localV
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/volumes/{volume}/bind"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.4/volumes/{volume}/bind"
 	localVarPath = strings.Replace(localVarPath, "{"+"volume"+"}", fmt.Sprintf("%v", volume), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -190,7 +201,18 @@ func (a *VolumeApiService) VolumeCreate(ctx context.Context, volume Volume) (*ht
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/volumes"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.4/volumes"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -302,8 +324,19 @@ func (a *VolumeApiService) VolumeDelete(ctx context.Context, volume string) (*ht
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/volumes/{volume}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.4/volumes/{volume}"
 	localVarPath = strings.Replace(localVarPath, "{"+"volume"+"}", fmt.Sprintf("%v", volume), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -418,8 +451,19 @@ func (a *VolumeApiService) VolumeGet(ctx context.Context, volume string) (Volume
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/volumes/{volume}"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.4/volumes/{volume}"
 	localVarPath = strings.Replace(localVarPath, "{"+"volume"+"}", fmt.Sprintf("%v", volume), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -543,7 +587,18 @@ func (a *VolumeApiService) VolumeList(ctx context.Context) ([]Volume, *http.Resp
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/volumes"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.4/volumes"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -654,7 +709,18 @@ func (a *VolumeApiService) VolumePlansList(ctx context.Context) (map[string]Volu
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/volumeplans"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarPath := "/1.4/volumeplans"
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -771,8 +837,19 @@ func (a *VolumeApiService) VolumeUnbind(ctx context.Context, volume string, loca
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/1.4/volumes/{volume}/bind"
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarPath := "/1.4/volumes/{volume}/bind"
 	localVarPath = strings.Replace(localVarPath, "{"+"volume"+"}", fmt.Sprintf("%v", volume), -1)
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/templates/api.mustache
+++ b/templates/api.mustache
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+  "path"
 {{#imports}}	"{{import}}"
 {{/imports}}
 )
@@ -77,8 +78,19 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "{{{path}}}"{{#pathParams}}
+	basePath, err := url.Parse(a.client.cfg.BasePath)
+	if err != nil {
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
+	}
+
+	localVarPath := "{{{path}}}"{{#pathParams}}
 	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", fmt.Sprintf("%v", {{paramName}}), -1){{/pathParams}}
+
+	u, err := url.Parse(localVarPath)
+	if err != nil {
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
+	}
+	localVarPath = basePath.ResolveReference(u).String()
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}


### PR DESCRIPTION
This PR resolves the following bug:

If tsuru-target has a slash at the end, such as: "https://my-host/"

when added the path, the url of the request will be wrong: "https://my-host//path"

This PR ensures that the URL will always be valid.